### PR TITLE
Add comment metadata macro

### DIFF
--- a/documentation/sample_queries.md
+++ b/documentation/sample_queries.md
@@ -72,6 +72,10 @@ group by 1, 2, 3, 4
 ```
 
 ## Query Cost Attribution
+Snowflake bills for the number of seconds that a warehouse is running, not by query. Query cost attribution helps understand how queries are contributing to warehouse active time. Removing a query will not reduce the bill by the exact amount attributed to the query if other queries are running at the same time and causing the warehouse to stay active.
+
+Cloud services credits are only billed if they exceed 10% of the compute credit consumption on a given day. The cost per query model accounts for this, but current day values will change up until the end of the day.
+
 
 ### Top 10 costliest queries in the last 30 days
 

--- a/integration_test_project/dbt_project.yml
+++ b/integration_test_project/dbt_project.yml
@@ -12,6 +12,10 @@ clean-targets:
   - target
   - dbt_packages
 
+query-comment:
+  comment: '{{ dbt_snowflake_monitoring.get_query_comment(node) }}'
+  append: true # Snowflake removes prefixed comments.
+
 vars: 
   DBT_SNOWFLAKE_MONITORING_SNOWFLAKE_ACCOUNT_USAGE_DATABASE: DBT_CI
   DBT_SNOWFLAKE_MONITORING_SNOWFLAKE_ACCOUNT_USAGE_SCHEMA: MOCK_DATA

--- a/integration_test_project/models/incremental.sql
+++ b/integration_test_project/models/incremental.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='incremental') }}
+
+select 1 as a

--- a/macros/get_query_comment.sql
+++ b/macros/get_query_comment.sql
@@ -1,0 +1,65 @@
+{# have to reimplement is_incremental because node.type hasn't populated #}
+{% macro custom_is_incremental(node) %}
+    {{ return(
+        node.config.materialized == 'incremental'
+        and not dbt_snowflake_monitoring.custom_should_full_refresh(node)
+    ) }}
+{% endmacro %}
+
+{% macro custom_should_full_refresh(node) %}
+  {% set config_full_refresh = node.config.get('full_refresh') %}
+  {% if config_full_refresh is none %}
+    {% set config_full_refresh = flags.FULL_REFRESH %}
+  {% endif %}
+  {% do return(config_full_refresh) %}
+{% endmacro %}
+
+{% macro get_query_comment(node) %}
+{%- set comment_dict = {} -%}
+{%- do comment_dict.update(
+    app='dbt',
+    dbt_version=dbt_version,
+    target_name=target.name,
+    target_database=target.database,
+    target_schema=target.schema,
+    invocation_id=invocation_id,
+) -%}
+{%- if env_var('DBT_CLOUD_PROJECT_ID', False) -%}
+  {%- do comment_dict.update(
+    dbt_cloud_project_id=env_var('DBT_CLOUD_PROJECT_ID')
+  ) -%}
+{%- endif -%}
+{%- if env_var('DBT_CLOUD_JOB_ID', False) -%}
+  {%- do comment_dict.update(
+    dbt_cloud_job_id=env_var('DBT_CLOUD_JOB_ID')
+  ) -%}
+{%- endif -%}
+{%- if env_var('DBT_CLOUD_RUN_ID', False) -%}
+  {%- do comment_dict.update(
+    dbt_cloud_run_id=env_var('DBT_CLOUD_RUN_ID')
+  ) -%}
+{%- endif -%}
+{%- if env_var('DBT_CLOUD_RUN_REASON_CATEGORY', False) -%}
+  {%- do comment_dict.update(
+    dbt_cloud_run_reason_category=env_var('DBT_CLOUD_RUN_REASON_CATEGORY')
+  ) -%}
+{%- endif -%}
+{%- if env_var('DBT_CLOUD_RUN_REASON', False) -%}
+  {%- do comment_dict.update(
+    dbt_cloud_run_reason=env_var('DBT_CLOUD_RUN_REASON')
+  ) -%}
+{%- endif -%}
+{%- if node is not none -%}
+  {%- do comment_dict.update(
+    node_id=node.unique_id,
+    node_resource_type=node.resource_type
+  ) -%}
+  {%- if node.resource_type == 'model' -%}
+  {%- do comment_dict.update(
+    materialized=node.config.materialized,
+    is_incremental=dbt_snowflake_monitoring.custom_is_incremental(node)
+  ) -%}
+  {%- endif -%}
+{%- endif -%}
+{{ return(tojson(comment_dict)) }}
+{% endmacro %}

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,9 @@ commands = sqlfluff lint {posargs} --ignore parsing
 
 [testenv:lint_all]
 deps = {[sqlfluff]deps}
-commands = sqlfluff lint models --ignore parsing
+commands =
+    dbt deps
+    sqlfluff lint models --ignore parsing
 
 [testenv:fix]
 deps = {[sqlfluff]deps}


### PR DESCRIPTION
Appends something like the following to all queries to allow the user to slice by the dimensions in the `dbt_metadata` column in `query_history_enriched`.

```/* {"app": "dbt", "dbt_version": "1.2.2", "target_name": "dev", "target_database": "dbt_ci", "target_schema": "niall", "invocation_id": "2508d791-6523-459a-b42e-44fc0f5acfd0", "dbt_cloud_project_id": "WOOHOO", "node_id": "model.dbt_snowflake_monitoring_tests.incremental", "node_resource_type": "model", "materialized": "incremental", "is_incremental": true} */;```