### PR TITLE
Allow dbt-utils 1.0.0

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<1.0.0"]
+    version: [">=0.8.0", "<=1.0.0"]

--- a/tox.ini
+++ b/tox.ini
@@ -97,12 +97,12 @@ deps = {[sqlfluff]deps}
 commands = sqlfluff fix models --ignore parsing -f
 
 [testenv:generate_docs]
-deps = dbt-snowflake~=1.2.0
+deps = dbt-snowflake~=1.3.0
 commands = dbt docs generate
 
 [testenv:integration_snowflake]
 changedir = integration_test_project
-deps = dbt-snowflake~=1.2.0
+deps = dbt-snowflake~=1.3.0
 commands =
     dbt deps
     dbt build -s +daily_spend --full-refresh
@@ -111,7 +111,7 @@ commands =
     dbt build --exclude dbt_snowflake_monitoring
 
 [testenv:snowflake]
-deps = dbt-snowflake~=1.2.0
+deps = dbt-snowflake~=1.3.0
 commands =
     dbt deps
     dbt build -s dbt_snowflake_monitoring --full-refresh


### PR DESCRIPTION
As far as I can tell the only usage in this package is the date_spine which isn't affected? Is building fine off of this fork