### PR TITLE
Increase incremental lookback window to account for changing cost data

### DIFF
--- a/.changes/unreleased/Fixes-20230106-215452.yaml
+++ b/.changes/unreleased/Fixes-20230106-215452.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Increase incremental lookback window to account for changing cost data
+time: 2023-01-06T21:54:52.198505-07:00
+custom:
+  Author: ian-whitestone
+  PR: "64"


### PR DESCRIPTION
With #62, we will now process queries before the rates have arrived for that day. This means the `cost_per_query` for the most recent day may change on the next run if the rates change.

`query_history_enriched` is an incremental model, so it will miss any changes. To accommodate this, I added a 7-day lookback period, so the incremental model will always re-process the last 7 days. The number 7 is arbitrary, it's very unlikely that the rates data would be delayed by more than a day or two.