### PR TITLE
fix/Update account ID example link in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ query-comment:
 The generate URLs to dbt Cloud jobs and runs in the `dbt_queries` model, add the following variable to `dbt_project.yml`:
 ```yaml
 vars:
-  dbt_cloud_account_id: 12345 # https://cloud.getdbt.com/next/deploy/<this_number>/
+  dbt_cloud_account_id: 12345 # https://cloud.getdbt.com/deploy/<this_number>/projects/<not_this_number>/jobs 
 ```
 
 ### Only want to use the get_query_comment macro?


### PR DESCRIPTION
Broken after the release of the dbt cloud UI update. An alternative proposal is a more precise link, but it is not as obvious a page https://cloud.getdbt.com/settings/accounts/<this_number>/