### PR TITLE
Feature: Add currency to Daily Spend and Daily Rates models

### DIFF
--- a/models/cost_per_query.sql
+++ b/models/cost_per_query.sql
@@ -149,7 +149,8 @@ select
     -- this may change if cloud credits make up >10% of compute cost.
     (div0(all_queries.credits_used_cloud_services, credits_billed_daily.daily_credits_used_cloud_services) * credits_billed_daily.daily_billable_cloud_services) * coalesce(daily_rates.effective_rate, current_rates.effective_rate) as cloud_services_cost,
     all_queries.compute_cost + cloud_services_cost as query_cost,
-    all_queries.ran_on_warehouse
+    all_queries.ran_on_warehouse,
+    coalesce(daily_rates.currency, current_rates.currency) as currency
 from all_queries
 inner join credits_billed_daily
     on date(all_queries.start_time) = credits_billed_daily.date

--- a/models/daily_rates.yml
+++ b/models/daily_rates.yml
@@ -18,6 +18,8 @@ models:
         description: The type of usage, which can be one of compute, storage, etc.
       - name: effective_rate
         description: The rate after applying any applicable discounts per the contract for the organization.
+      - name: currency
+        description: Currency of effect rate, retrieved from Snowflake's daily rate sheet
       - name: is_overage_rate
         description: Indicator for whether the effective_rate is an overage rate.
       - name: is_latest_rate

--- a/models/daily_spend.sql
+++ b/models/daily_spend.sql
@@ -83,7 +83,7 @@ storage_spend_daily as (
             0
         ) as spend,
         spend as spend_net_cloud_services,
-        any_value(daily_rates.currency) as currency
+        any_value(coalesce(daily_rates.currency, latest_rates.currency)) as currency
     from dates
     left join
         storage_terabytes_daily on dates.date = storage_terabytes_daily.date

--- a/models/daily_spend.sql
+++ b/models/daily_spend.sql
@@ -82,7 +82,8 @@ storage_spend_daily as (
             ),
             0
         ) as spend,
-        spend as spend_net_cloud_services
+        spend as spend_net_cloud_services,
+        any_value(daily_rates.currency) as currency
     from dates
     left join
         storage_terabytes_daily on dates.date = storage_terabytes_daily.date
@@ -111,7 +112,8 @@ compute_spend_daily as (
             ),
             0
         ) as spend,
-        spend as spend_net_cloud_services
+        spend as spend_net_cloud_services,
+        any_value(daily_rates.currency) as currency
     from dates
     left join {{ ref('stg_metering_history') }} on
         dates.date = convert_timezone(
@@ -144,7 +146,8 @@ serverless_task_spend_daily as (
             ),
             0
         ) as spend,
-        spend as spend_net_cloud_services
+        spend as spend_net_cloud_services,
+        any_value(daily_rates.currency) as currency
     from dates
     left join {{ ref('stg_serverless_task_history') }} on
         dates.date = convert_timezone(
@@ -175,7 +178,8 @@ adj_for_incl_cloud_services_daily as (
             ),
             0
         ) as spend,
-        0 as spend_net_cloud_services
+        0 as spend_net_cloud_services,
+        any_value(daily_rates.currency) as currency
     from dates
     left join {{ ref('stg_metering_daily_history') }} on
         dates.date = stg_metering_daily_history.date
@@ -205,7 +209,10 @@ _cloud_services_spend_daily as (
         ) as credits_used_cloud_services,
         any_value(
             coalesce(daily_rates.effective_rate, latest_rates.effective_rate)
-        ) as effective_rate
+        ) as effective_rate,
+        any_value(
+            coalesce(daily_rates.currency, latest_rates.currency)
+        ) as currency
     from dates
     left join {{ ref('stg_metering_history') }} on
         dates.date = convert_timezone(
@@ -249,7 +256,8 @@ cloud_services_spend_daily as (
                 _cloud_services_spend_daily.credits_used_cloud_services,
                 credits_billed_daily.daily_credits_used_cloud_services
             ) * credits_billed_daily.daily_billable_cloud_services
-        ) * _cloud_services_spend_daily.effective_rate as spend_net_cloud_services
+        ) * _cloud_services_spend_daily.effective_rate as spend_net_cloud_services,
+        currency as currency
     from _cloud_services_spend_daily
     inner join credits_billed_daily on
                _cloud_services_spend_daily.date = credits_billed_daily.date
@@ -271,7 +279,8 @@ automatic_clustering_spend_daily as (
             ),
             0
         ) as spend,
-        spend as spend_net_cloud_services
+        spend as spend_net_cloud_services,
+        any_value(daily_rates.currency) as currency
     from dates
     left join {{ ref('stg_metering_history') }} on
         dates.date = convert_timezone(
@@ -303,7 +312,8 @@ materialized_view_spend_daily as (
             ),
             0
         ) as spend,
-        spend as spend_net_cloud_services
+        spend as spend_net_cloud_services,
+        any_value(daily_rates.currency) as currency
     from dates
     left join {{ ref('stg_metering_history') }} on
         dates.date = convert_timezone(
@@ -335,7 +345,8 @@ snowpipe_spend_daily as (
             ),
             0
         ) as spend,
-        spend as spend_net_cloud_services
+        spend as spend_net_cloud_services,
+        any_value(daily_rates.currency) as currency
     from dates
     left join {{ ref('stg_metering_history') }} on
         dates.date = convert_timezone(
@@ -367,7 +378,8 @@ query_acceleration_spend_daily as (
             ),
             0
         ) as spend,
-        spend as spend_net_cloud_services
+        spend as spend_net_cloud_services,
+        any_value(daily_rates.currency) as currency
     from dates
     left join {{ ref('stg_metering_history') }} on
         dates.date = convert_timezone(
@@ -399,7 +411,8 @@ replication_spend_daily as (
             ),
             0
         ) as spend,
-        spend as spend_net_cloud_services
+        spend as spend_net_cloud_services,
+        any_value(daily_rates.currency) as currency
     from dates
     left join {{ ref('stg_metering_history') }} on
         dates.date = convert_timezone(
@@ -431,7 +444,8 @@ search_optimization_spend_daily as (
             ),
             0
         ) as spend,
-        spend as spend_net_cloud_services
+        spend as spend_net_cloud_services,
+        any_value(daily_rates.currency) as currency
     from dates
     left join {{ ref('stg_metering_history') }} on
         dates.date = convert_timezone(

--- a/models/daily_spend.yml
+++ b/models/daily_spend.yml
@@ -15,4 +15,6 @@ models:
     - name: database_name
       description: Subcategories where service = "Serverless Tasks" or service = "Storage" and storage_type = "Table and Time Travel" or "Failsafe".
     - name: spend
-      description: Spend in the account's currency.
+      description: Spend in the currency described by the 'currency' column
+    - name: currency
+      description: Spend currency, retrieved from Snowflake's daily rate sheet

--- a/models/query_history_enriched.sql
+++ b/models/query_history_enriched.sql
@@ -131,7 +131,8 @@ select
     query_history.queued_overload_time / 1000 as queued_overload_time_s,
     query_history.transaction_blocked_time / 1000 as transaction_blocked_time_s,
     query_history.list_external_files_time / 1000 as list_external_files_time_s,
-    query_history.execution_time / 1000 as execution_time_s
+    query_history.execution_time / 1000 as execution_time_s,
+    cost_per_query.currency
 
 from query_history
 inner join cost_per_query


### PR DESCRIPTION
Adding currency to Daily Rates and Daily Spend, to allow model consumers with mixed currencies in their rate sheets to unify the spend-currency in their reporting.

Solves #99.

