### PR TITLE
Add node_meta to dbt_query

### DIFF
--- a/.changes/unreleased/Features-20230526-161501.yaml
+++ b/.changes/unreleased/Features-20230526-161501.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add node_meta to dbt_query model
+time: 2023-05-26T16:15:01.927389+01:00
+custom:
+  Author: pratik60
+  PR: "109"

--- a/models/dbt_queries.sql
+++ b/models/dbt_queries.sql
@@ -12,6 +12,7 @@ select
     dbt_metadata['materialized']::string as dbt_node_materialized,
     dbt_metadata['is_incremental']::boolean as dbt_node_is_incremental,
     dbt_metadata['node_alias']::string as dbt_node_alias,
+    dbt_metadata['node_meta']::variant as dbt_node_meta,
     dbt_metadata['node_tags']::array as node_tags,
     iff(dbt_snowflake_query_tags_version >= '1.1.3', dbt_metadata['node_refs']::array, []) as dbt_node_refs, -- correct refs available from 1.1.3 onwards
     dbt_metadata['node_database']::string as dbt_node_database,

--- a/models/dbt_queries.yml
+++ b/models/dbt_queries.yml
@@ -20,6 +20,8 @@ models:
         description: Boolean describing if the node run was incremental.
       - name: dbt_node_alias
         description: Alias set for the node.
+      - name: dbt_node_meta
+        description: Dict of any meta set for the node.
       - name: dbt_node_tags
         description: Array of all tags set for the node.
       - name: dbt_node_refs

--- a/packages.yml
+++ b/packages.yml
@@ -2,4 +2,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.8.0", "<2.0.0"]
   - package: get-select/dbt_snowflake_query_tags
-    version: 2.0.2
+    version: 2.1.0


### PR DESCRIPTION
Follow up to: https://github.com/get-select/dbt-snowflake-query-tags/pull/13

I have no data on my local, but got an error on the incremental model. The [config of append_new_columns](https://github.com/get-select/dbt-snowflake-monitoring/blob/main/dbt_project.yml#L14) was not working for me even if I put it in the same model, so its perhaps my environment which is borked. 🤔  

**Running a full refresh did work!**

Can you test this locally?
```
12:23:26  Compilation Error in model dbt_queries (models/dbt_queries.sql)
12:23:26    
12:23:26                  The source and target schemas on this incremental model are out of sync!
12:23:26                  They can be reconciled in several ways:
12:23:26                    - set the `on_schema_change` config to either append_new_columns or sync_all_columns, depending on your situation.
12:23:26                    - Re-run the incremental model with `full_refresh: True` to update the target schema.
12:23:26                    - update the schema manually and re-run the process.
12:23:26    
12:23:26                  Additional troubleshooting context:
12:23:26                     Source columns not in target: [SnowflakeColumn(column='DBT_NODE_META', dtype='VARIANT', char_size=None, numeric_precision=None, numeric_scale=None)]
12:23:26                     Target columns not in source: []
12:23:26                     New column types: [] 
```