### PR TITLE
Undo `service_type` transformation in `stg_rate_sheet_daily` and fix `service_type` filters in `cost_per_query` and `hourly_spend`

### DIFF
--- a/models/cost_per_query.sql
+++ b/models/cost_per_query.sql
@@ -102,7 +102,7 @@ query_cost as (
             and query_seconds_per_hour.hour = credits_billed_hourly.hour
     inner join {{ ref('daily_rates') }} as daily_rates
         on date(query_seconds_per_hour.start_time) = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'WAREHOUSE_METERING'
             and daily_rates.usage_type = 'compute'
 ),
 
@@ -188,10 +188,10 @@ inner join credits_billed_daily
     on date(all_queries.start_time) = credits_billed_daily.date
 left join {{ ref('daily_rates') }} as daily_rates
     on date(all_queries.start_time) = daily_rates.date
-        and daily_rates.service_type = 'COMPUTE'
+        and daily_rates.service_type = 'WAREHOUSE_METERING'
         and daily_rates.usage_type = 'cloud services'
 inner join {{ ref('daily_rates') }} as current_rates
     on current_rates.is_latest_rate
-        and current_rates.service_type = 'COMPUTE'
+        and current_rates.service_type = 'WAREHOUSE_METERING'
         and current_rates.usage_type = 'cloud services'
 order by all_queries.start_time asc

--- a/models/cost_per_query.sql
+++ b/models/cost_per_query.sql
@@ -188,10 +188,10 @@ inner join credits_billed_daily
     on date(all_queries.start_time) = credits_billed_daily.date
 left join {{ ref('daily_rates') }} as daily_rates
     on date(all_queries.start_time) = daily_rates.date
-        and daily_rates.service_type = 'WAREHOUSE_METERING'
+        and daily_rates.service_type = 'CLOUD_SERVICES'
         and daily_rates.usage_type = 'cloud services'
 inner join {{ ref('daily_rates') }} as current_rates
     on current_rates.is_latest_rate
-        and current_rates.service_type = 'WAREHOUSE_METERING'
+        and current_rates.service_type = 'CLOUD_SERVICES'
         and current_rates.usage_type = 'cloud services'
 order by all_queries.start_time asc

--- a/models/hourly_spend.sql
+++ b/models/hourly_spend.sql
@@ -128,7 +128,7 @@ compute_spend_hourly as (
         )
     left join {{ ref('daily_rates') }} as daily_rates
         on hours.hour::date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'WAREHOUSE_METERING'
             and daily_rates.usage_type = 'compute'
     where
         stg_metering_history.service_type = 'WAREHOUSE_METERING' and stg_metering_history.name != 'CLOUD_SERVICES_ONLY'
@@ -155,7 +155,7 @@ serverless_task_spend_hourly as (
         hours.hour = date_trunc('hour', stg_serverless_task_history.start_time)
     left join {{ ref('daily_rates') }} as daily_rates
         on hours.hour::date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'SERVERLESS_TASK'
             and daily_rates.usage_type = 'serverless tasks'
     group by 1, 2, 3, 4, 5
 ),
@@ -180,7 +180,7 @@ adj_for_incl_cloud_services_hourly as (
         hours.hour = stg_metering_daily_history.date
     left join {{ ref('daily_rates') }} as daily_rates
         on hours.hour::date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'CLOUD_SERVICES'
             and daily_rates.usage_type = 'cloud services'
     group by 1, 2, 3, 4
 ),
@@ -243,7 +243,7 @@ cloud_services_spend_hourly as (
         _cloud_services_usage_hourly.date = _cloud_services_billed_daily.date
     left join {{ ref('daily_rates') }} as daily_rates
         on _cloud_services_usage_hourly.date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'CLOUD_SERVICES'
             and daily_rates.usage_type = 'cloud services'
 
 ),
@@ -271,7 +271,7 @@ automatic_clustering_spend_hourly as (
         and stg_metering_history.service_type = 'AUTO_CLUSTERING'
     left join {{ ref('daily_rates') }} as daily_rates
         on hours.hour::date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'AUTOMATIC_CLUSTERING'
             and daily_rates.usage_type = 'automatic clustering'
     group by 1, 2, 3, 4
 ),
@@ -299,7 +299,7 @@ materialized_view_spend_hourly as (
         and stg_metering_history.service_type = 'MATERIALIZED_VIEW'
     left join {{ ref('daily_rates') }} as daily_rates
         on hours.hour::date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'MATERIALIZED_VIEW'
             and daily_rates.usage_type = 'materialized views'
     group by 1, 2, 3, 4
 ),
@@ -327,7 +327,7 @@ snowpipe_spend_hourly as (
         and stg_metering_history.service_type = 'PIPE'
     left join {{ ref('daily_rates') }} as daily_rates
         on hours.hour::date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'SNOWPIPE'
             and daily_rates.usage_type = 'snowpipe'
     group by 1, 2, 3, 4
 ),
@@ -355,7 +355,7 @@ snowpipe_streaming_spend_hourly as (
         and stg_metering_history.service_type = 'SNOWPIPE_STREAMING'
     left join {{ ref('daily_rates') }} as daily_rates
         on hours.hour::date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'SNOWPIPE_STREAMING'
             and daily_rates.usage_type = 'snowpipe streaming'
     group by 1, 2, 3, 4
 ),
@@ -383,7 +383,7 @@ query_acceleration_spend_hourly as (
         and stg_metering_history.service_type = 'QUERY_ACCELERATION'
     left join {{ ref('daily_rates') }} as daily_rates
         on hours.hour::date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'QUERY_ACCELERATION'
             and daily_rates.usage_type = 'query acceleration'
     group by 1, 2, 3, 4
 ),
@@ -411,7 +411,7 @@ replication_spend_hourly as (
         and stg_metering_history.service_type = 'REPLICATION'
     left join {{ ref('daily_rates') }} as daily_rates
         on hours.hour::date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'REPLICATION'
             and daily_rates.usage_type = 'replication'
     group by 1, 2, 3, 4
 ),
@@ -439,7 +439,7 @@ search_optimization_spend_hourly as (
         and stg_metering_history.service_type = 'SEARCH_OPTIMIZATION'
     left join {{ ref('daily_rates') }} as daily_rates
         on hours.hour::date = daily_rates.date
-            and daily_rates.service_type = 'COMPUTE'
+            and daily_rates.service_type = 'SEARCH_OPTIMIZATION'
             and daily_rates.usage_type = 'search optimization'
     group by 1, 2, 3, 4
 ),

--- a/models/staging/stg_rate_sheet_daily.sql
+++ b/models/staging/stg_rate_sheet_daily.sql
@@ -12,13 +12,6 @@ select
     usage_type,
     currency,
     effective_rate,
-    case
-        -- For most Snowflake accounts, the service_type field is always COMPUTE or STORAGE
-        -- Have recently seen new values introduced for one account: WAREHOUSE_METERING and CLOUD_SERVICES
-        -- For now, we'll force these to either be COMPUTE or STORAGE since that's what the downstream models expect
-        -- May adjust this in the future if Snowflake is permanently changing these fields for all accounts and starts offering different credit rates per usage_type
-        when service_type = 'STORAGE' then 'STORAGE'
-        else 'COMPUTE'
-    end as service_type
+    service_type
 from {{ source('snowflake_organization_usage', 'rate_sheet_daily') }}
 order by date


### PR DESCRIPTION
This PR undoes the `CASE` statement that forced the daily rate sheet `service_type` to either `STORAGE` or `COMPUTE` in `stg_rate_sheet_daily` and fixes all `service_type` filters in the package accordingly.

I cross referenced the hard-coded `service_type` values with [snowflake.organization_usage.rate_sheet_daily](https://docs.snowflake.com/en/sql-reference/organization-usage/rate_sheet_daily), [snowflake.account_usage.metering_history](https://docs.snowflake.com/en/sql-reference/account-usage/metering_history) and [snowflake.account_usage.metering_daily_history](https://docs.snowflake.com/en/sql-reference/account-usage/metering_daily_history). I also did manual validation checks to ensure that the compute spend values are being populated in the `daily_spend` model. 