### PR TITLE
Bump sqlfluff

### DIFF
--- a/models/staging/stg_serverless_task_history.sql
+++ b/models/staging/stg_serverless_task_history.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized='incremental',
     unique_key=['start_time', 'task_id'],
-)  }}
+) }}
 
 select
     start_time,

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 envlist = integration_snowflake
 
 [sqlfluff]
-exclude_rules = LT05, ST06, RF04, AM06, ST05, LT02
+exclude_rules = LT05, ST06, RF04, AM06, ST05, LT02, CV06
 dialect = snowflake
 templater = dbt
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ exclude_rules = LT05, ST06, RF04, AM06, ST05, LT02
 dialect = snowflake
 templater = dbt
 deps =
-    sqlfluff-templater-dbt==2.*
+    sqlfluff-templater-dbt==3.2.0
     dbt-snowflake~=1.5.0
 
 [testenv]
@@ -34,11 +34,11 @@ commands =
 
 [testenv:fix]
 deps = {[sqlfluff]deps}
-commands = sqlfluff fix {posargs} --ignore parsing -f
+commands = sqlfluff fix {posargs} --ignore parsing
 
 [testenv:fix_all]
 deps = {[sqlfluff]deps}
-commands = sqlfluff fix models --ignore parsing -f
+commands = sqlfluff fix models --ignore parsing
 
 [testenv:generate_docs]
 deps = dbt-snowflake~=1.5.0


### PR DESCRIPTION
1. Bump to latest sqlfluff. I think a good idea to pin to latest version for now, but I'm open to other ideas.
2. Fix the thing [failing in your CI](https://github.com/get-select/dbt-snowflake-monitoring/actions/runs/10525723638/job/29165076502).
3. Remove `-f` flag since "The -f/--force option is deprecated as it is now the default behaviour."
4. Ignore [CV06 Statements must end with a semi-colon](https://docs.sqlfluff.com/en/stable/reference/rules.html#rule-convention.terminator), which would trigger in about 15 of your files.