### PR TITLE
Add retry columns to query_history_enriched

### DIFF
--- a/models/query_history_enriched.sql
+++ b/models/query_history_enriched.sql
@@ -141,7 +141,12 @@ select
     query_history.transaction_blocked_time / 1000 as transaction_blocked_time_s,
     query_history.list_external_files_time / 1000 as list_external_files_time_s,
     query_history.execution_time / 1000 as execution_time_s,
-    cost_per_query.currency
+    cost_per_query.currency,
+    query_history.query_retry_time as query_retry_time_ms,
+    query_history.query_retry_time / 1000 as query_retry_time_s,
+    query_history.query_retry_cause as query_retry_cause,
+    query_history.fault_handling_time as fault_handling_time_ms,
+    query_history.fault_handling_time / 1000 as fault_handling_time_s
 
 from query_history
 inner join cost_per_query

--- a/models/query_history_enriched.yml
+++ b/models/query_history_enriched.yml
@@ -197,3 +197,13 @@ models:
         description: Contains the original query text stripped of any comments.
       - name: dbt_metadata
         description: Metadata from the JSON string added to the query by dbt. Null if no metadata was added.
+      - name: query_retry_time_ms
+        description: Total execution time (in milliseconds) for query retries caused by actionable errors.
+      - name: query_retry_time_s
+        description: Total execution time (in seconds) for query retries caused by actionable errors.
+      - name: query_retry_cause
+        description: Error that caused the query to retry. If there is no query retry, the field is NULL.
+      - name: fault_handling_time_ms
+        description: Total execution time (in milliseconds) for query retries caused by errors that are not actionable.
+      - name: fault_handling_time_s
+        description: Total execution time (in seconds) for query retries caused by errors that are not actionable.


### PR DESCRIPTION
There are new columns in the Query History system view from Snowflake, and I'd like to have those available in the dbt model query_history_enriched.
This PR adds the following columns:
      - name: query_retry_time_ms
        description: Total execution time (in milliseconds) for query retries caused by actionable errors.
      - name: query_retry_time_s
        description: Total execution time (in seconds) for query retries caused by actionable errors.
      - name: query_retry_cause
        description: Error that caused the query to retry. If there is no query retry, the field is NULL.
      - name: fault_handling_time_ms
        description: Total execution time (in milliseconds) for query retries caused by errors that are not actionable.
      - name: fault_handling_time_s
        description: Total execution time (in seconds) for query retries caused by errors that are not actionable.