### PR TITLE
Increase service spend coverage

### DIFF
--- a/models/hourly_spend.sql
+++ b/models/hourly_spend.sql
@@ -518,7 +518,7 @@ query_acceleration_spend_hourly as (
 other_costs as (
     select
         hours.hour,
-        initcap(service_type) as service
+        initcap(replace(stg_metering_history.service_type, '_', ' ')) as service,
         null as storage_type,
         null as warehouse_name,
         null as database_name,
@@ -546,7 +546,9 @@ other_costs as (
         'PIPE', 'QUERY_ACCELERATION',
         'SERVERLESS_TASK', 'WAREHOUSE_METERING', 'WAREHOUSE_METERING_READER'
     )
-)
+
+    group by 1, 2, 3, 4
+),
 
 unioned as (
     select * from storage_spend_hourly


### PR DESCRIPTION
There are new Snowflake services (such as SENSITIVE_DATA_CLASSIFICATION, DATA_QUALITY_MONITORING, SERVERLESS_ALERTS, TRUST_CENTER) which are not covered today by our `hourly_spend` because we have 1 CTE per service.

This PR adds a new CTE to catch any service that is in `metering_history` and currently not covered by our `hourly_spend`.