### PR TITLE
Fix join clause on hourly_spend

### DIFF
--- a/models/hourly_spend.sql
+++ b/models/hourly_spend.sql
@@ -450,6 +450,11 @@ other_costs as (
     left join {{ ref('daily_rates') }} as daily_rates
         on hour::date = daily_rates.date
             and _service_renamed = daily_rates.service_type
+            /* daily_rates can have multiple rows for the same service_type,
+               with different values in usage_type (eg: usage_type = "automatic clustering" or
+               "adjustment-automatic clustering"). We want to join only with the row where
+               usage_type is the same as the service_type */
+            and lower(service) = daily_rates.usage_type
 
     -- Covered by their own CTEs due to more complex logic or better sources
     where stg_metering_history.service_type not in (


### PR DESCRIPTION
The recent PR https://github.com/get-select/dbt-snowflake-monitoring/pull/173 introduced a new CTE on `hourly_spend` to fetch the spend from several services from `metering_history` and it also removed a few existing CTEs that would be covered by the new CTE.

The new CTE, however, lacked a clause on a JOIN, which caused the JOIN to fan out on cases when there are multiple rows in `daily_rates` for the same service (eg: for the `AUTOMATIC_CLUSTERING` service, there could be 2 rows with `usage_type = 'automatic clustering'` and `usage_type = 'adjustment-automatic clustering'`). This causes spend to be overreported on those cases.

This PR restores the extra clause on the JOIN that was present before to prevent this fan out.