### PR TITLE
Filtering potential duplicates from query_history

### DIFF
--- a/models/staging/stg_query_history.sql
+++ b/models/staging/stg_query_history.sql
@@ -82,4 +82,6 @@ from {{ source('snowflake_account_usage', 'query_history') }}
     where end_time > (select dateadd(day, -{{ var('dbt_snowflake_monitoring_incremental_days', '2') }}, coalesce(max(end_time), '1970-01-01') ) from {{ this }})
 {% endif %}
 
+qualify (row_number() over (partition by query_id, start_time order by start_time )) = 1
+
 order by start_time

--- a/models/staging/stg_query_history.sql
+++ b/models/staging/stg_query_history.sql
@@ -82,6 +82,6 @@ from {{ source('snowflake_account_usage', 'query_history') }}
     where end_time > (select dateadd(day, -{{ var('dbt_snowflake_monitoring_incremental_days', '2') }}, coalesce(max(end_time), '1970-01-01') ) from {{ this }})
 {% endif %}
 
-qualify (row_number() over (partition by query_id, start_time order by start_time )) = 1
+qualify row_number() over (partition by query_id order by start_time ) = 1
 
 order by start_time


### PR DESCRIPTION
We need to avoid potential duplicates from the Snowflake QUERY_HISTORY system view.
Snowflake's article: https://community.snowflake.com/s/article/Why-ACCOUNT-USAGE-QUERY-HISTORY-view-returns-duplicate-rows-for-one-query