### PR TITLE
required config for dbt-fusion

### DIFF
--- a/models/query_history_enriched.sql
+++ b/models/query_history_enriched.sql
@@ -1,4 +1,5 @@
 {{ config(
+    static_analysis="off",
     materialized='incremental',
     unique_key=['query_id', 'start_time'],
     pre_hook=["{{ create_merge_objects_udf(this) }}"]


### PR DESCRIPTION
The udf function fails to compile in dbt fusion.  I added one line of config to turn of static analysis for the model that has the prehook to create the UDF.

Context:
https://getdbt.slack.com/archives/C088YCAB6GH/p1748486640501319