### PR TITLE
Update query_history_enriched.sql

### DIFF
--- a/models/query_history_enriched.sql
+++ b/models/query_history_enriched.sql
@@ -13,7 +13,7 @@ query_history as (
         -- this removes comments enclosed by /* <comment text> */ and single line comments starting with -- and either ending with a new line or end of string
         regexp_replace(query_text, $$(\/\*(.|\n|\r)*?\*\/)|(--.*$)|(--.*(\n|\r))|;$$, '') as query_text_no_comments,
 
-        try_parse_json(regexp_substr(query_text, $$\/\*\s*({(.|\n|\r)*"app":\s"dbt"(.|\n|\r)*})\s*\*\/$$, 1, 1, 'ie')) as _dbt_json_comment_meta,
+        try_parse_json(regexp_substr(query_text, $$\/\*\s*({[^*]*?"app":\s*"dbt"[^*]*})\s*\*\/$$, 1, 1, 'ie')) as _dbt_json_comment_meta,
         case
             when try_parse_json(query_tag)['dbt_snowflake_query_tags_version'] is not null then try_parse_json(query_tag)
         end as _dbt_json_query_tag_meta,


### PR DESCRIPTION
Sometimes, dbt inserts two blocks of query comments into the query text, with each block added by a separate process. As a result, the current regular expression cannot correctly handle multi-block query comments, leading to inaccurate metadata generation (for example, a NULL DBT_PROJECT_NAME).

I am updating the regular expression to support both single-block and multi-block query comments effectively.

![image](https://github.com/user-attachments/assets/63a4b3f1-530f-42a8-975c-10ecdd7df2ae)

Please refer to the example shown in the picture above, where two query comment blocks are present. The current pattern, shown under the column "old_dbt_json_comment_meta", fails to be parsed correctly by the TRY_PARSE_JSON function, resulting in a NULL value.

The new pattern, however, handles this scenario effectively, allowing TRY_PARSE_JSON to return the proper JSON value under the column "new_dbt_json_comment_meta".